### PR TITLE
fix date parsing bug when the preferredDateFormat is "do MMM yyyy"

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -167,6 +167,8 @@ export const getDateForPageWithoutBrackets = (
     return `${d.toLocaleString("default", {
       month: "long",
     })} ${getOrdinalNum(getDate)}, ${getYear}`;
+  } else if (preferredDateFormat === "do MMM yyyy") {
+    return `${getOrdinalNum(getDate)} ${getMonth} ${getYear}`;
   } else {
     return `${getMonth} ${getOrdinalNum(getDate)}, ${getYear}`;
   }


### PR DESCRIPTION
Hi ~ I found that your awesome plugin "logseq-quicktodo-plugin" don't parse correct today's journal page name when the preferredDateFormat is "do MMM yyyy". Further, I found that that plugin uses this project to provide date resolution. So I open this PR to fix this tinny bug.